### PR TITLE
Store emoji↔text associations for speeches (squashed)

### DIFF
--- a/frontend/src/test/components/SpeechDetail.test.jsx
+++ b/frontend/src/test/components/SpeechDetail.test.jsx
@@ -1,18 +1,32 @@
 
 // Mock fetch and dependencies BEFORE importing the component
+// Mock the emoji-mart v5 Picker to a simple test-friendly component
+jest.mock('@emoji-mart/react', () => {
+  return ({ onEmojiSelect }) => {
+    return (
+      <div>
+        <button onClick={() => onEmojiSelect({ native: '😀' })}>😀</button>
+        <button onClick={() => onEmojiSelect({ native: '😂' })}>😂</button>
+      </div>
+    );
+  };
+});
 const mockSpeech = {
   name: 'Test Speech',
   content: 'Hello world! This is a test.',
   createdAt: Date.now(),
 };
 
-globalThis.fetch = jest.fn((url) => {
+// Capture fetch calls so tests can assert on them
+let fetchCalls = [];
+globalThis.fetch = jest.fn((url, opts = {}) => {
+  fetchCalls.push({ url, opts });
   console.log('MOCK FETCH CALLED:', url);
   if (url.includes('getSpeech')) {
-    return Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve(mockSpeech),
-    });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(mockSpeech) });
+  }
+  if (url.includes('saveEmojiAssociation')) {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ message: 'saved' }) });
   }
   return Promise.resolve({ ok: false, json: () => Promise.resolve({ message: 'error' }) });
 });
@@ -40,7 +54,8 @@ import { waitFor } from '@testing-library/react';
 
 describe('SpeechDetail', () => {
   beforeEach(() => {
-    fetch.mockClear();
+  fetch.mockClear();
+  fetchCalls = [];
   });
 
 
@@ -61,7 +76,7 @@ describe('SpeechDetail', () => {
     await act(async () => {
       window._setSpeechSelection({ start: 0, end: mockSpeech.content.length, text: mockSpeech.content });
     });
-    expect(screen.getByText('Replace with Emoji')).toBeInTheDocument();
+  expect(screen.getByText(/Replace with Emoji/)).toBeInTheDocument();
   });
 
 
@@ -72,7 +87,7 @@ describe('SpeechDetail', () => {
     await act(async () => {
       window._setSpeechSelection({ start: 0, end: mockSpeech.content.length, text: mockSpeech.content });
     });
-    fireEvent.click(screen.getByText('Replace with Emoji'));
+  fireEvent.click(screen.getByText(/Replace with Emoji/));
     expect(screen.getByText('Pick an Emoji')).toBeInTheDocument();
     expect(screen.getByText('😀')).toBeInTheDocument();
   });
@@ -85,8 +100,68 @@ describe('SpeechDetail', () => {
     await act(async () => {
       window._setSpeechSelection({ start: 0, end: mockSpeech.content.length, text: mockSpeech.content });
     });
-    fireEvent.click(screen.getByText('Replace with Emoji'));
+  fireEvent.click(screen.getByText(/Replace with Emoji/));
     fireEvent.click(screen.getByText('😀'));
     expect(screen.queryByText('Replace with Emoji')).not.toBeInTheDocument();
+  });
+
+  it('posts emoji association to backend with expected payload', async () => {
+    render(<SpeechDetail />);
+    await waitFor(() => expect(screen.queryByText('Loading speech details...')).not.toBeInTheDocument());
+    await act(async () => {
+      window._setSpeechSelection({ start: 0, end: mockSpeech.content.length, text: mockSpeech.content });
+    });
+    fireEvent.click(screen.getByText(/Replace with Emoji/));
+    fireEvent.click(screen.getByText('😀'));
+
+    // Wait for the saveEmojiAssociation fetch to be recorded
+    await waitFor(() => expect(fetchCalls.find(c => c.url.includes('saveEmojiAssociation'))).toBeDefined());
+
+    const call = fetchCalls.find(c => c.url.includes('saveEmojiAssociation'));
+    expect(call.opts.method).toBe('POST');
+    const payload = JSON.parse(call.opts.body);
+    expect(payload.speechId).toBe('test-id');
+    expect(payload.originalText).toBe(mockSpeech.content);
+    expect(payload.emoji).toBe('😀');
+    expect(payload.position).toBe(0);
+    expect(payload.cleanSpeech).toBe(mockSpeech.content);
+  });
+
+  it('handles saveEmojiAssociation failure gracefully', async () => {
+    // Make fetch return ok for getSpeech, but fail for saveEmojiAssociation
+    const originalFetch = global.fetch;
+    let callCount = 0;
+    global.fetch = jest.fn((url, opts = {}) => {
+      callCount++;
+      if (url.includes('getSpeech')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockSpeech) });
+      }
+      // Simulate server error on save
+      if (url.includes('saveEmojiAssociation')) {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({ message: 'save failed' }) });
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({ message: 'error' }) });
+    });
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<SpeechDetail />);
+    await waitFor(() => expect(screen.queryByText('Loading speech details...')).not.toBeInTheDocument());
+    await act(async () => {
+      window._setSpeechSelection({ start: 0, end: mockSpeech.content.length, text: mockSpeech.content });
+    });
+    fireEvent.click(screen.getByText(/Replace with Emoji/));
+    fireEvent.click(screen.getByText('😀'));
+
+    // UI should still reflect the emoji replacement
+    const contentEl = await screen.findByTestId('speech-content');
+    expect(contentEl.textContent).toContain('😀');
+
+    // save failure should cause console.error to be called inside saveEmojiAssociation catch
+    await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+
+    // Restore
+    consoleErrorSpy.mockRestore();
+    global.fetch = originalFetch;
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,15 @@
         "backend/functions"
       ],
       "dependencies": {
+        "@emoji-mart/data": "^1.2.1",
+        "@emoji-mart/react": "^1.1.1",
+        "emoji-mart": "^5.6.0",
         "firebase": "^12.0.0",
         "firebase-admin": "^13.4.0",
         "firebase-functions": "^6.4.0",
-        "firebase-functions-test": "^3.4.1"
+        "firebase-functions-test": "^3.4.1",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "concurrently": "^9.2.0"
@@ -111,10 +116,12 @@
         "@testing-library/react": "^16.0.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "babel-plugin-module-resolver": "^5.0.2",
         "eslint": "^8.57.0",
         "eslint-plugin-react-hooks": "^4.6.2",
         "eslint-plugin-react-refresh": "^0.4.7",
         "globals": "^15.4.0",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "vite": "^7.0.6"
@@ -2096,6 +2103,20 @@
       "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emoji-mart/data": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
+      "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw=="
+    },
+    "node_modules/@emoji-mart/react": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
+      "peerDependencies": {
+        "emoji-mart": "^5.2",
+        "react": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -5491,6 +5512,70 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "dev": true,
+      "dependencies": {
+        "find-babel-config": "^2.1.1",
+        "glob": "^9.3.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.8"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/babel-plugin-module-resolver/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
@@ -6333,6 +6418,11 @@
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
+    "node_modules/emoji-mart": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-5.6.0.tgz",
+      "integrity": "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow=="
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -7106,6 +7196,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/find-babel-config": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.2.tgz",
+      "integrity": "sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.3"
+      }
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -8376,6 +8475,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -8550,6 +8655,18 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -11238,7 +11355,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -11624,7 +11740,6 @@
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -11640,8 +11755,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
@@ -11686,6 +11800,79 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-up/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-up/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pkg-up/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/postcss": {
@@ -11929,7 +12116,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11941,7 +12127,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12112,6 +12297,12 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,15 @@
     "start:prod": "npm run build --workspace=frontend && npm run deploy --workspace=functions"
   },
   "dependencies": {
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
+    "emoji-mart": "^5.6.0",
     "firebase": "^12.0.0",
     "firebase-admin": "^13.4.0",
     "firebase-functions": "^6.4.0",
-    "firebase-functions-test": "^3.4.1"
+    "firebase-functions-test": "^3.4.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "concurrently": "^9.2.0"


### PR DESCRIPTION
This PR implements storing emoji↔text associations for speeches and was squashed into a single commit.

Changes included:
- Frontend:  UI to replace selected text with an emoji using an emoji picker, unit tests, and a transient toast shown on save failures.
- Backend: Cloud Function endpoint  which saves { originalText, emoji, position, createdAt } to  and merges  into the speech document.

Notes:
- The feature branch was squashed into a single commit for a cleaner history. A backup branch  preserves the original commits.
- Tests: Frontend unit tests pass locally (7 tests).
- Next steps: consider adding a retry action in the toast and replacing the inline toast with  for better UX.
