### PR TITLE
Emoji associations: assocId, toggle persistence, tests & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,119 @@
+# Trippingly
+
+Trippingly lets users upload speeches, replace highlighted words or phrases with emojis, and persist those emoji↔text associations. This repo contains a Vite + React frontend and Firebase Cloud Functions (Express) backend using Firestore.
+
+This README explains the project layout, how to run the app locally (frontend + functions), how to run tests, and where to look for the emoji-association logic.
+
+## Project overview
+
+- Frontend: `frontend/` — Vite + React app, Jest + React Testing Library tests.
+- Backend: `backend/functions/` — Firebase Cloud Functions (Express) with Firestore via `firebase-admin`.
+
+The core feature added in the current branch is emoji↔text associations with stable `assocId`s, client toggling (emoji vs original text), localStorage persistence, and server-side persistence for associations and toggles.
+
+## Repository structure
+
+- `frontend/` — React app
+  - `src/components/SpeechDetail.jsx` — main UI for speech display, selection, emoji replacement, and toggling.
+  - `src/test/components/` — unit tests for UI behaviors.
+  - `src/setupTests.js` — test setup helpers and warnings filter.
+
+- `backend/functions/` — Firebase Cloud Functions
+  - `index.js` — Express app exposing endpoints like `/getSpeech`, `/saveEmojiAssociation`, `/updateAssociationToggle`, `/uploadSpeech`.
+
+## Local development
+
+Prerequisites
+- Node.js (tested with Node 20)
+- npm
+- Firebase CLI (optional, for emulators and deploys)
+- A Firebase project with Firestore and Authentication configured (for full end-to-end testing)
+
+Frontend
+
+1. Install dependencies:
+
+```bash
+cd frontend
+npm install
+```
+
+2. Start the dev server:
+
+```bash
+npm run dev
+```
+
+3. Environment variables
+
+- The frontend expects `VITE_CLOUD_FUNCTION_URL` to point to the backend (Cloud Functions) base URL. When running functions locally with the Firebase emulator, set `VITE_CLOUD_FUNCTION_URL` to the functions emulator host (for example, `http://localhost:5001/<project>/us-central1/api`). You can set this in `.env` or export in your shell before starting the frontend.
+
+Backend (Cloud Functions)
+
+1. Install dependencies:
+
+```bash
+cd backend/functions
+npm install
+```
+
+2. Run emulators (recommended for local testing):
+
+```bash
+npm run serve
+```
+
+This starts the Functions, Auth, and Firestore emulators (if configured). See `firebase.json` and emulator docs for details.
+
+3. Key endpoints
+
+- `GET /getSpeech/:speechId` — fetch a speech owned by the authenticated user.
+- `POST /saveEmojiAssociation` — save an emoji association; accepts `assocId` (optional) and `showOriginal`.
+- `POST /updateAssociationToggle` — update `showOriginal` for an association.
+
+Authentication
+
+Both frontend and backend calls expect Firebase Authentication tokens. During local development, either sign in through the emulator UI, or mock `currentUser.getIdToken()` in tests.
+
+## Running tests
+
+Frontend tests use Jest + React Testing Library. From the repo root:
+
+```bash
+CI=true npm --prefix frontend test
+```
+
+The frontend test suite includes tests that mock the emoji picker and network requests.
+
+## Notes for maintainers
+
+- Associations are stored client-side under `localStorage` key `speech_assoc:{speechId}` with shape `{ associations: [...], toggles: { [assocId]: boolean } }`.
+- Backend saves associations to Firestore under `users/{userId}/speeches/{speechId}/emojiAssociations` and will use an incoming `assocId` as the document id when provided (idempotent writes).
+- Toggle state (`showOriginal`) can be persisted server-side via `POST /updateAssociationToggle`.
+
+## Testing manual changes (quick guide)
+
+1. Start Firestore + Functions emulators locally (if you want to test persistence):
+
+```bash
+cd backend/functions
+npm run serve
+```
+
+2. Start the frontend dev server and set `VITE_CLOUD_FUNCTION_URL` to the emulator URL.
+
+3. Use the UI to upload a speech, select text, replace with emoji, and toggle the association. Check Firestore emulator UI to confirm documents are created under the user's `speeches/{speechId}/emojiAssociations`.
+
+## Next work / TODOs
+
+- Add integration tests using Firebase emulator for end-to-end verification.
+- Improve accessibility focus-trap for the emoji picker modal.
+- Migrate any remaining legacy localStorage shapes in a migration utility (most migration is handled on-load currently).
+
+## Contribution
+
+1. Open a PR against `main` with a clear description and testing steps.
+2. Include unit tests for new behaviors and run the frontend test suite locally.
+
+---
+If anything is unclear or you'd like me to add automated CI or emulator-based integration tests, I can add them next.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -39,6 +39,20 @@ button:disabled {
   cursor: not-allowed;
 }
 
+.assoc-button {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.assoc-button:focus-visible {
+  outline: 3px solid #0056b3;
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 input[type='file'], input[type='text'], input[type='email'], input[type='password'] {
   width: 100%;
   padding: 10px;

--- a/frontend/src/components/SpeechDetail.jsx
+++ b/frontend/src/components/SpeechDetail.jsx
@@ -303,7 +303,12 @@ const SpeechDetail = () => {
           {renderSegments().map((s, i) => {
             if (s.type === 'text') return (<span key={`t-${i}`}>{s.text}</span>);
             return (
-              <button key={`a-${s.key}`} onClick={() => toggleAssociation(s.key)} style={{ background: 'transparent', border: 'none', padding: 0, margin: 0, cursor: 'pointer' }} aria-label={`toggle-${s.key}`}>
+              <button
+                key={`a-${s.key}`}
+                onClick={() => toggleAssociation(s.key)}
+                style={{ background: 'transparent', border: 'none', padding: 0, margin: 0, cursor: 'pointer', color: 'inherit', font: 'inherit' }}
+                aria-label={`toggle-${s.key}`}
+              >
                 {s.text}
               </button>
             );

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -6,3 +6,14 @@ if (typeof global.TextEncoder === 'undefined') {
   global.TextEncoder = TextEncoder;
   global.TextDecoder = TextDecoder;
 }
+
+// Silence known non-actionable React Router future-flag warnings in tests
+const origWarn = console.warn;
+console.warn = (...args) => {
+  try {
+    const msg = args && args[0] && String(args[0]);
+    if (msg && msg.includes('React Router Future Flag Warning')) return;
+    if (msg && msg.includes('Relative route resolution within Splat routes is changing')) return;
+  } catch (e) {}
+  origWarn.apply(console, args);
+};

--- a/frontend/src/test/components/SpeechDetail.test.jsx
+++ b/frontend/src/test/components/SpeechDetail.test.jsx
@@ -48,7 +48,7 @@ jest.mock('../../../src/context/AuthContext', () => {
 
 import React from 'react';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import SpeechDetail from '../../../src/components/SpeechDetail';
 import { waitFor } from '@testing-library/react';
 
@@ -127,6 +127,8 @@ describe('SpeechDetail', () => {
     expect(payload.emoji).toBe('😀');
     expect(payload.position).toBe(0);
     expect(payload.cleanSpeech).toBe(mockSpeech.content);
+  // New: ensure assocId was included for idempotent saves
+  expect(typeof payload.assocId).toBe('string');
   });
 
   it('handles saveEmojiAssociation failure gracefully', async () => {

--- a/frontend/src/test/components/SpeechDetail.test.jsx
+++ b/frontend/src/test/components/SpeechDetail.test.jsx
@@ -47,7 +47,7 @@ jest.mock('../../../src/context/AuthContext', () => {
 });
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import SpeechDetail from '../../../src/components/SpeechDetail';
 import { waitFor } from '@testing-library/react';
@@ -101,7 +101,8 @@ describe('SpeechDetail', () => {
       window._setSpeechSelection({ start: 0, end: mockSpeech.content.length, text: mockSpeech.content });
     });
   fireEvent.click(screen.getByText(/Replace with Emoji/));
-    fireEvent.click(screen.getByText('😀'));
+  // Click the emoji inside the opened picker modal
+  fireEvent.click(within(screen.getByText('Pick an Emoji').parentElement).getByText('😀'));
     expect(screen.queryByText('Replace with Emoji')).not.toBeInTheDocument();
   });
 
@@ -112,7 +113,8 @@ describe('SpeechDetail', () => {
       window._setSpeechSelection({ start: 0, end: mockSpeech.content.length, text: mockSpeech.content });
     });
     fireEvent.click(screen.getByText(/Replace with Emoji/));
-    fireEvent.click(screen.getByText('😀'));
+  // Click the emoji inside the opened picker modal
+  fireEvent.click(within(screen.getByText('Pick an Emoji').parentElement).getByText('😀'));
 
     // Wait for the saveEmojiAssociation fetch to be recorded
     await waitFor(() => expect(fetchCalls.find(c => c.url.includes('saveEmojiAssociation'))).toBeDefined());
@@ -151,7 +153,8 @@ describe('SpeechDetail', () => {
       window._setSpeechSelection({ start: 0, end: mockSpeech.content.length, text: mockSpeech.content });
     });
     fireEvent.click(screen.getByText(/Replace with Emoji/));
-    fireEvent.click(screen.getByText('😀'));
+  // Click the emoji inside the opened picker modal
+  fireEvent.click(within(screen.getByText('Pick an Emoji').parentElement).getByText('😀'));
 
     // UI should still reflect the emoji replacement
     const contentEl = await screen.findByTestId('speech-content');


### PR DESCRIPTION
This PR adds stable assocId handling for emoji↔text associations, client and server persistence for toggles, test updates, and a README to help contributors run the project locally.